### PR TITLE
Mdd fix repo file errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/hmrc/security-git-hooks
-    rev: v1.6.0
+    rev: release/1.9.0
     hooks:
     -   id: secrets_filename
         files: ''

--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ verify_ssl = true
 tox = "*"
 
 [requires]
-python_version = "3.9.1"
+python_version = "3.10"

--- a/security_git_hooks/secrets_filecontent.py
+++ b/security_git_hooks/secrets_filecontent.py
@@ -20,22 +20,22 @@ def repository_yaml_check(repository_yaml):
     - return rulesets according to value
 
     """
-
-    with open(repository_yaml, "r") as file:
-        yamlfile = yaml.safe_load(file)
-        if (
-            yamlfile["repoVisibility"]
-            == "public_0C3F0CE3E6E6448FAD341E7BFA50FCD333E06A20CFF05FCACE61154DDBBADF71"
-        ):
-            return PUBLIC_RULES
-        elif (
-            yamlfile["repoVisibility"]
-            == "private_12E5349CFB8BBA30AF464C24760B70343C0EAE9E9BD99156345DD0852C2E0F6F"
-        ):
-            return PRIVATE_RULES
-        else:
-            print("no repository.yaml data found, searching against all rules")
-            return PUBLIC_RULES
+    try:
+        with open(repository_yaml, "r") as file:
+            yamlfile = yaml.safe_load(file)
+            if (
+                yamlfile["repoVisibility"]
+                == "public_0C3F0CE3E6E6448FAD341E7BFA50FCD333E06A20CFF05FCACE61154DDBBADF71"
+            ):
+                return PUBLIC_RULES
+            elif (
+                yamlfile["repoVisibility"]
+                == "private_12E5349CFB8BBA30AF464C24760B70343C0EAE9E9BD99156345DD0852C2E0F6F"
+            ):
+                return PRIVATE_RULES
+    except FileNotFoundError:
+        print("no repository.yaml data found, searching against all rules")
+        return PUBLIC_RULES
 
 
 repository_yaml_check("repository.yaml")

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,20 @@
 [tox]
-envlist = pre-commit,lint,py39
-indexserver =
-    default = https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple
+envlist = pre-commit,lint,py310
 
 [testenv]
-deps = 
+deps =
     pytest
     pytest-cov
 commands =
     pytest -v
 
 [testenv:lint]
-deps = 
+deps =
     black
     flake8
     flake8-bugbear
     flake8-colors
-commands = 
+commands =
     black .
     flake8
 
@@ -61,4 +59,4 @@ exclude = .git,__pycache__,build,dist,.tox
 max-line-length = 120
 ignore=D103,D107,W503,D104
 
-    
+


### PR DESCRIPTION
This fixes https://github.com/hmrc/security-git-hooks/issues/22  by correctly catching the exception if the repository.yaml file does not exist. No test case written yet since it would mean adding a whole new form of testing, ideally with real repositories, and I'd like some comment on how to do that. 