### PR TITLE
BAU Requires setuptools so that security hooks work OOTB

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/hmrc/security-git-hooks
-    rev: v1.6.0
+    rev: release/1.9.0
     hooks:
     -   id: secrets_filename
         files: ''

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         ]
     },
     packages=find_packages(),
-    install_requires=["PyYAML", "requests"],
+    install_requires=["PyYAML", "requests", "setuptools"],
     tests_require=["pytest"],
     package_data={"": ["conf.yaml"]},
 )


### PR DESCRIPTION
What we have done
--

1. Update the version of security-hooks it uses to test itself from v1.6.0 to v1.9.0
2. Fixed this bug: `ModuleNotFoundError: No module named 'pkg_resources'` which occurs because the version of Python 3.12 that pre-commit configured did not have `setuptools` available by default
    a. This _may_ be unique to me but happened consistently across repositories

Evidence of work
--

I pointed my local failing repos temporarily to the following and it started working:

```yaml
  - repo: https://github.com/gavd/security-git-hooks
    rev: BAU-require-setuptools
```

Risks
--

1. I don't know why it was installing 3.12! Python versions, dependencies and environments are seldom straightforward!

Next steps
--

1. Will this change automatically cut a new release? If not, we will need one :-)
2. We would recommend updating the `.pre-commit-config.yaml` to the latest release

Collaborators
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
